### PR TITLE
Implement REx checksum calculation in a lazy-ish way

### DIFF
--- a/tools/fmemopen.c
+++ b/tools/fmemopen.c
@@ -1,0 +1,92 @@
+/*
+// Copyright 2012 Jeff Verkoeyen
+// Originally ported from https://github.com/ingenuitas/python-tesseract/blob/master/fmemopen.c
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+
+struct fmem {
+  size_t pos;
+  size_t size;
+  char *buffer;
+};
+typedef struct fmem fmem_t;
+
+static int readfn(void *handler, char *buf, int size) {
+  fmem_t *mem = handler;
+  size_t available = mem->size - mem->pos;
+
+  if (size > available) {
+    size = available;
+  }
+  memcpy(buf, mem->buffer, sizeof(char) * size);
+  mem->pos += size;
+
+  return size;
+}
+
+static int writefn(void *handler, const char *buf, int size) {
+  fmem_t *mem = handler;
+  size_t available = mem->size - mem->pos;
+
+  if (size > available) {
+    size = available;
+  }
+  memcpy(mem->buffer, buf, sizeof(char) * size);
+  mem->pos += size;
+
+  return size;
+}
+
+static fpos_t seekfn(void *handler, fpos_t offset, int whence) {
+  size_t pos;
+  fmem_t *mem = handler;
+
+  switch (whence) {
+    case SEEK_SET: pos = offset; break;
+    case SEEK_CUR: pos = mem->pos + offset; break;
+    case SEEK_END: pos = mem->size + offset; break;
+    default: return -1;
+  }
+
+  if (pos > mem->size) {
+    return -1;
+  }
+
+  mem->pos = pos;
+  return (fpos_t)pos;
+}
+
+static int closefn(void *handler) {
+  free(handler);
+  return 0;
+}
+
+FILE *fmemopen(void *buf, size_t size, const char *mode) {
+  // This data is released on fclose.
+  fmem_t* mem = (fmem_t *) malloc(sizeof(fmem_t));
+
+  // Zero-out the structure.
+  memset(mem, 0, sizeof(fmem_t));
+
+  mem->size = size;
+  mem->buffer = buf;
+
+  // funopen's man page: https://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man3/funopen.3.html
+  return funopen(mem, readfn, writefn, seekfn, closefn);
+}

--- a/tools/fmemopen.h
+++ b/tools/fmemopen.h
@@ -1,0 +1,53 @@
+/*
+// Copyright 2012 Jeff Verkoeyen
+// Original from https://raw.githubusercontent.com/tmm1/fmemopen/master/fmemopen.h
+// Originally ported from https://github.com/ingenuitas/python-tesseract/blob/master/fmemopen.c
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#ifndef FMEMOPEN_H_
+#define FMEMOPEN_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * A BSD port of the fmemopen Linux method using funopen.
+ *
+ * man docs for fmemopen:
+ * http://linux.die.net/man/3/fmemopen
+ *
+ * man docs for funopen:
+ * https://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man3/funopen.3.html
+ *
+ * This method is ported from ingenuitas' python-tesseract project.
+ *
+ * You must call fclose on the returned file pointer or memory will be leaked.
+ *
+ *      @param buf The data that will be used to back the FILE* methods. Must be at least
+ *                 @c size bytes.
+ *      @param size The size of the @c buf data.
+ *      @param mode The permitted stream operation modes.
+ *      @returns A pointer that can be used in the fread/fwrite/fseek/fclose family of methods.
+ *               If a failure occurred NULL will be returned.
+ */
+FILE *fmemopen(void *buf, size_t size, const char *mode);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // #ifndef FMEMOPEN_H_


### PR DESCRIPTION
I have *not* tested this `BuildRex` on macOS, yet.  Please do so before accepting this PR.

I've implemented (I hope) the REx checksum calculation (from cDCL's `Rex.cpp`) in a lazy way: used `fmemopen()` to open memory buffer as a file stream, so none of the existing file-writing code needed to be changed.

This requires an implementation of `fmemopen()` on macOS, which is included if needed.  

Fixed a problem I was having with the `manufacturer` string: the Apple REx0 has the bytes `0x01 0x00 0x00 0x00` in the manufacturer header field; in order to read this value back properly from a config file created with `DumpRex`, I needed to check whether the `cfgManufacturer` value ended in a `'` character.

